### PR TITLE
Corrected wrong href pluralsight

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@
 ### Courses
 
 🎓 - [Learn Bulma CSS for free](https://scrimba.com/g/gbulma) - Shimba  
-🎓 - [Building Websites with Bulma](https://www.youtube.com/watch?v=7gX_ApBeSpQ) - Pluralsight  
+🎓 - [Building Websites with Bulma](https://www.pluralsight.com/courses/building-websites-bulma) - Pluralsight  
 🎓 - [Learn Bulma CSS for free](https://coursesity.com/course-detail/learn-bulma-css-for-free-) - Coursesity
 
 ## UI Libraries & Components


### PR DESCRIPTION
Changed the pluralsight link from the README. It's named "Building websites with bulma - Pluralsight  " but it pointed to a yt vid about tailwind. The video also isn't the same guy as the one that has the course on pluralsight. The pluralsight course actually has the the title "Building websites with bulma". 

Not sure if the tailwind one should have been removed but it did not look bulma related.  