### PR TITLE
Update Bestax entry and add create-bestax starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
 
 ### Starters
 
+🏁 - [create-bestax](https://www.npmjs.com/package/create-bestax) - A starter for React/Bestax/Bulma/AI-powered development, built for Bulma v1  
+
 ***Note:** These starters are built for **Bulma v0.9** and are not yet compatible with v1.*  
 🏁 - [bulma-start](https://github.com/jgthms/bulma-start) - A tiny npm package to get started  
 🏁 - [gatsby-starter-netlify-cms](https://github.com/netlify-templates/gatsby-starter-netlify-cms) - Gatsby + Decap CMS (formerly Netlify CMS) with Bulma  
@@ -152,7 +154,7 @@
 - [buefy](https://buefy.org/) - Lightweight UI components for Vue.js based on Bulma
 - [oruga](https://github.com/oruga-ui/oruga) - UI components library without CSS framework dependency
 - [oruga-ui/theme-bulma](https://github.com/oruga-ui/theme-bulma) - Bulma theme for Oruga components
-- [bestax-bulma](https://github.com/allxsmith/bestax) - Fully typed React components for Bulma
+- [Bestax](https://github.com/allxsmith/bestax) - A full-featured React library for Bulma, built for AI-powered development
 - [blazorise](https://github.com/Megabit/Blazorise) - Components for Blazor with support for Bulma
 - [react-bulma-components](https://github.com/couds/react-bulma-components/) - React components for Bulma
 - [bulma-rails](https://github.com/joshuajansen/bulma-rails/) - Integrates Bulma with the rails asset pipeline


### PR DESCRIPTION
Two small updates for Bestax:

- **UI Libraries & Components:** updated the existing `bestax-bulma` entry to its current name and description — Bestax is a full-featured React library for Bulma, built for AI-powered development.
- **Starters:** added `create-bestax`, a starter for React/Bestax/Bulma/AI-powered development. Unlike the other starters in this section, it is built for Bulma v1.

Thanks @aldi for finding Bestax and adding it to the list — super awesome!